### PR TITLE
Release Candidate 2017.05

### DIFF
--- a/download_espa_order.py
+++ b/download_espa_order.py
@@ -55,7 +55,12 @@ class Api(object):
         if data:
             data = json.dumps(data)
 
-        request = ul.Request(self.host + endpoint, data=data)
+        if sys.version_info[0] == 3:
+            request = ul.Request(self.host + endpoint, data=data.encode(),
+                                 method='GET')
+        else:
+            request = ul.Request(self.host + endpoint, data=data)
+            request.get_method = lambda: 'GET'
 
         base64string = (base64
                         .encodestring('%s:%s' % (self.username, self.password))

--- a/download_espa_order.py
+++ b/download_espa_order.py
@@ -71,7 +71,14 @@ class Api(object):
         except ul.HTTPError as e:
             result = e
 
-        return json.loads(result.read().decode())
+        resp = json.loads(result.read().decode())
+        if isinstance(resp, dict):
+            messages = resp.pop('messages', dict())
+            if messages.get('errors'):
+                raise Exception('ERRORS: {}'.format(messages.get('errors')))
+            if messages.get('warnings'):
+                print('WARNINGS: {}'.format(messages.get('warnings')))
+        return resp
 
     def get_completed_scenes(self, orderid):
         resp = self.api_request('/api/v1/item-status/{0}'.format(orderid))

--- a/download_espa_order.py
+++ b/download_espa_order.py
@@ -78,33 +78,22 @@ class Api(object):
                 raise Exception('ERRORS: {}'.format(messages.get('errors')))
             if messages.get('warnings'):
                 print('WARNINGS: {}'.format(messages.get('warnings')))
+
         return resp
 
     def get_completed_scenes(self, orderid):
-        resp = self.api_request('/api/v1/item-status/{0}'.format(orderid))
-
-        if "msg" in resp:
-            raise Exception(resp)
-
-        return [_.get('product_dload_url') for _ in resp['orderid'][orderid] if _.get('product_dload_url')]
+        filters = {'status': 'complete'}
+        resp = self.api_request('/api/v1/item-status/{0}'.format(orderid),
+                                data=filters)
+        urls = [_.get('product_dload_url') for _ in resp[orderid]]
+        return urls
 
     def retrieve_all_orders(self, email):
-        ret = []
-        url = '/api/v1/list-orders'
-        if email:
-            url += '/{0}'.format(email)
-        all_orders = self.api_request(url)['orders']
+        filters = {'status': 'complete'}
+        all_orders = self.api_request('/api/v1/list-orders/{0}'.format(email),
+                                      data=filters)
 
-        # Need to sift through and only pull non-purged orders
-        for o in all_orders:
-            resp = self.api_request('/api/v1/order-status/{0}'.format(o))
-
-            if 'msg' in resp:
-                raise Exception(resp)
-            elif 'status' in resp and resp['status'] != 'purged':
-                ret.append(o)
-
-        return ret
+        return all_orders
 
     def __enter__(self):
         return self


### PR DESCRIPTION
## Status
**Ready for use in system/integration testing**

## Description
* Updates all urllib2 calls to use GET against the API, using JSON filters for "completed" only
* Removes unnecessary "orders" and "orderid" field parsing from API response

## Related PR's
branch | PR
-|-
2017.May.Dev| [espa-api#83](https://github.com/USGS-EROS/espa-api/pull/83)

## Tests
Manually tested downloads using python versions: `2.7.5`, `2.7.13`, `3.5.3`, `3.6.1`