### PR TITLE
Optional Checksum Verification [RC 2017.08]

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ download_espa_order.py -h
 Argument | Description
 ---|---
 `-e or --email` | The email address used to submit the order
-`-o or --order` | The order you wish to download.  Maybe also use `ALL`
+`-o or --order` | The order you wish to download.  (`ALL` or ESPA order-id)
 `-d or --target_directory` | The local directory to store downloaded scenes
 `-u or --username` | Your ERS username
 `-p or --password` | Your ERS password
 `-c or --checksum` | Download and compare MD5 hash
 
-Linux/Mac Example: `python ./download_espa_order.py -e your_email@server.com -o ALL -d /some/directory/with/free/space -u foo -p bar`
+Linux/Mac Example: `python ./download_espa_order.py -e your_email@server.com -d /some/directory/with/free/space -u foo -p bar`
 
-Windows Example: `C:\python27\python download_espa_order.py -e your_email@server.com -o ALL -d C:\some\directory\with\free\space -u foo -p bar`
+Windows Example: `C:\python27\python download_espa_order.py -e your_email@server.com -d C:\some\directory\with\free\space -u foo -p bar`
 
 # Notes
 Retrieves all completed scenes for the user/order

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Argument | Description
 `-d or --target_directory` | The local directory to store downloaded scenes
 `-u or --username` | Your ERS username
 `-p or --password` | Your ERS password
-`-c or --checksum` | Download and compare MD5 hash
+`-c or --checksum` | Download checksum files (will also compare the contents)
 
 Linux/Mac Example: `python ./download_espa_order.py -e your_email@server.com -d /some/directory/with/free/space -u foo -p bar`
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
+# espa-bulk-downloader
+
 Automatically downloads all completed espa scenes.  Each scene is downloaded to the `--target_directory` and organized by order.
 
 # Installation
-* Note: These were tested with python 2.7.
+* Note: These were tested with both python 2.7.13 and 3.6.5.
 
 * Clone this repository:
 ```
@@ -17,15 +19,15 @@ download_espa_order.py -h
 * Alternatively you can just download the stand alone zip file which only requires python to run
 
 ### Runtime options
-`-e or --email` The email address used to submit the order
 
-`-o or --order` The order you wish to download.  Maybe also use `ALL`
-
-`-d or --target_directory` The local directory to store downloaded scenes
-
-`-u or --username` Your ERS username
-
-`-p or --password` Your ERS password
+Argument | Description
+---|---
+`-e or --email` | The email address used to submit the order
+`-o or --order` | The order you wish to download.  Maybe also use `ALL`
+`-d or --target_directory` | The local directory to store downloaded scenes
+`-u or --username` | Your ERS username
+`-p or --password` | Your ERS password
+`-c or --checksum` | Download and compare MD5 hash
 
 Linux/Mac Example: `python ./download_espa_order.py -e your_email@server.com -o ALL -d /some/directory/with/free/space -u foo -p bar`
 

--- a/download_espa_order.py
+++ b/download_espa_order.py
@@ -92,7 +92,7 @@ class Api(object):
 
     def retrieve_all_orders(self, email):
         filters = {'status': 'complete'}
-        all_orders = self.api_request('/api/v1/list-orders/{0}'.format(email),
+        all_orders = self.api_request('/api/v1/list-orders/{0}'.format(email or ''),
                                       data=filters)
 
         return all_orders
@@ -313,15 +313,15 @@ if __name__ == '__main__':
               '\n ')
 
     parser = argparse.ArgumentParser(epilog=epilog, formatter_class=argparse.RawDescriptionHelpFormatter)
-    
+
     parser.add_argument("-e", "--email",
                         required=False,
                         help="email address for the user that submitted the order)")
-                        
+
     parser.add_argument("-o", "--order",
-                        required=True,
+                        required=False, default='ALL',
                         help="which order to download (use ALL for every order)")
-                        
+
     parser.add_argument("-d", "--target_directory",
                         required=True,
                         help="where to store the downloaded scenes")


### PR DESCRIPTION
## Description
Refactored optional ability to download `.md5` checksum file, and also verify the binary contents of the `.tar.gz` product. Intended as an early-warning utility for detecting data corrupted in transit

## Impacted Areas in Application

* Refactors handling of a download, to be re-used to grab `.md5` file as well
* Adds a soft comparison after download, to check if the hash contained in `.md5` matches the hash calculated on the `.tar.gz` binary contents (only prints warning if different)
* Removes the requirement to supply `--order`, allowing users to always download their own orders
