### PR TITLE
Python 2.7.9 and Requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,21 +3,30 @@
 Automatically downloads all completed espa scenes.  Each scene is downloaded to the `--target_directory` and organized by order.
 
 # Installation
-* Note: These were tested with both python 2.7.13 and 3.6.5.
 
+## Requirements
+
+* Python Version >= 2.7.9 (required for HTTPS)
+* Note:
+  * These were tested with both python 2.7.14 and 3.6.4.
+  * For Python Version >= 2.6.0, the [requests][3] library must be installed.
+
+
+## Install
+* Install with pip automatically:
+```
+pip install git+https://github.com/USGS-EROS/espa-bulk-downloader.git
+download_espa_order.py -h
+```
 * Clone this repository:
 ```
 git clone https://github.com/USGS-EROS/espa-bulk-downloader.git bulk-downloader
 cd bulk-downloader
 python ./download_espa_order.py -h
 ```
-* Install with pip automatically:
-```
-pip install git+https://github.com/USGS-EROS/espa-bulk-downloader.git
-download_espa_order.py -h
-```
-* Alternatively you can just download the stand alone zip file which only requires python to run
+* Alternatively you can [download the stand alone zip][1] file which only requires python to run (see [requirements](#requirements))
 
+# Usage
 ### Runtime options
 
 Argument | Description
@@ -27,11 +36,11 @@ Argument | Description
 `-d or --target_directory` | The local directory to store downloaded scenes
 `-u or --username` | Your ERS username
 `-p or --password` | Your ERS password
-`-c or --checksum` | Download checksum files (will also compare the contents)
+`-c or --checksum` | Download checksum files
 
-Linux/Mac Example: `python ./download_espa_order.py -e your_email@server.com -d /some/directory/with/free/space -u foo -p bar`
+> Linux/Mac Example: `python ./download_espa_order.py -e your_email@server.com -d /some/directory/with/free/space -u foo`
 
-Windows Example: `C:\python27\python download_espa_order.py -e your_email@server.com -d C:\some\directory\with\free\space -u foo -p bar`
+> Windows Example: `C:\python27\python download_espa_order.py -e your_email@server.com -d C:\some\directory\with\free\space -u foo`
 
 # Notes
 Retrieves all completed scenes for the user/order
@@ -40,7 +49,7 @@ Scenes are organized by order.
 
 It is safe to cancel and restart the client, as it will
 only download scenes one time (per directory)
- 
+
 If you intend to automate execution of this script,
 please take care to ensure only 1 instance runs at a time.
 Also please do not schedule execution more frequently than
@@ -56,5 +65,6 @@ This project is unsupported software provided by the U.S. Geological Survey (USG
 This software is preliminary or provisional and is subject to revision. It is being provided to meet the need for timely best science. The software has not received final approval by the U.S. Geological Survey (USGS). No warranty, expressed or implied, is made by the USGS or the U.S. Government as to the functionality of the software and related material nor shall the fact of release constitute any such warranty. The software is provided on the condition that neither the USGS nor the U.S. Government shall be held liable for any damages resulting from the authorized or unauthorized use of the software.
 
 
+[1]: https://github.com/USGS-EROS/espa-bulk-downloader/archive/master.zip
 [2]: mailto:custserv@usgs.gov
-    
+[3]: https://github.com/requests/requests

--- a/download_espa_order.py
+++ b/download_espa_order.py
@@ -6,10 +6,11 @@ Purpose: A simple python client that will download all available (completed) sce
 
 Requires: Standard Python installation.
 
-Version: 1.0
+Version: 2.2
 
 Changes:
 
+31 Jan 2017: Updated HTTPS support for python >= 2.7.9
 20 June 2017: Woodstonelee added option to download checksum and error handling on bad urls
 30 June 2016: Guy Serbin added support for Python 3.x and download progress indicators.
 24 August 2016: Guy Serbin added:

--- a/download_espa_order.py
+++ b/download_espa_order.py
@@ -359,4 +359,4 @@ if __name__ == '__main__':
     except KeyboardInterrupt:
         LOGGER.error('User killed process')
     except Exception as exc:
-        LOGGER.critical(exc.message, exc_info=os.getenv('DEBUG', False))
+        LOGGER.critical('ERROR: %s' % exc, exc_info=os.getenv('DEBUG', False))

--- a/setup.py
+++ b/setup.py
@@ -31,8 +31,9 @@ setup(
 
     # Dependent packages (distributions)
     install_requires=[
-    ],
+        'requests',
+        ],
 
     # Supported Python versions
-    python_requires='>=2.7.9',
+    python_requires='>=2.7',
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     name='download_espa_order',
 
     # Version number:
-    version='2.1.0',
+    version='2.2.0',
 
     # Application author details:
     author='USGS EROS ESPA',
@@ -31,5 +31,8 @@ setup(
 
     # Dependent packages (distributions)
     install_requires=[
-     ],
+    ],
+
+    # Supported Python versions
+    python_requires='>=2.7.9',
 )


### PR DESCRIPTION
## Description
Updates required for HTTPS migration (Jan 31) in order to support the Python 2.7 release series

## Impacted Areas

* **REQUIRES** [requests](https://github.com/requests/requests) library for Python < 2.7.9 
  + This avoids known Windows SSL problems, without re-writting most of the http library
* For Python >= 2.7.9, use the standard ssl/http library for creating HTTPS connections
  + Also, prefer using requests if it is already installed

