### PR TITLE
Fix user auth for python3+requests

### DIFF
--- a/download_espa_order.py
+++ b/download_espa_order.py
@@ -124,7 +124,7 @@ class RequestsHandler(object):
 
     def auth(self, username, password):
         basic = ('%s:%s' % (username, password)).encode('ascii')
-        self.headers = {'Authorization': 'Basic %s' % base64.b64encode(basic)}
+        self.headers = {'Authorization': 'Basic %s' % base64.b64encode(basic).decode()}
 
     def get(self, uri, data=None):
         response = requests.get(self.host+uri, json=data, headers=self.headers)


### PR DESCRIPTION
## Description

Due to how Python 3 handles bytes vs strings, add a decode before generating the user authentication header string for the requests library, which is preventing python3 users from supplying their credentials

## Related 

* [espa-api#104 ](/USGS-EROS/espa-api/pull/104) 
