### PR TITLE
Create executable script on Windows when pip-installed

### DIFF
--- a/download_espa_order.py
+++ b/download_espa_order.py
@@ -306,7 +306,7 @@ def main(username, email, order, target_directory, password=None, host=None, ver
                 storage.store(scene, checksum, retry)
 
 
-if __name__ == '__main__':
+def main():
     epilog = ('ESPA Bulk Download Client Version 1.0.0. [Tested with Python 2.7]\n'
               'Retrieves all completed scenes for the user/order\n'
               'and places them into the target directory.\n'
@@ -385,3 +385,7 @@ if __name__ == '__main__':
         LOGGER.error('User killed process')
     except Exception as exc:
         LOGGER.critical('ERROR: %s' % exc, exc_info=os.getenv('DEBUG', False))
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,11 @@ setup(
     # Moves the script to the user's bin directory so that it can be executed.
     # Usage is 'download_espa_order.py' not 'python download_espa_order.py'
     scripts=['download_espa_order.py'],
+    entry_points={
+        'console_scripts': [
+            'download_espa_order = download_espa_order:main'
+        ]
+    },
 
     # Dependent packages (distributions)
     install_requires=[


### PR DESCRIPTION
Currently when installed on Windows using pip there is no way to run the script without digging into site-packages to find the script, or to install manually, losing the ease of use with pip.

This PR adds an ``entry_points={'console_scripts': []}`` entry for `download_espa_order`, which creates an executable file wrapping the script on Windows, allowing equivalent usage to the current behaviour on Linux e.g. after running ``pip install``, on Windows, I can do the following:

```
$ download_espa_order.exe -h
usage: download_espa_order [-h] [-e EMAIL] [-o ORDER] -d TARGET_DIRECTORY -u
                           USERNAME [-p PASSWORD] [-v] [-i HOST] [-c]
                           [-r {1,2,3,4,5,6,7,8,9,10}] [-n]
```

This change should not affect behaviour on Linux, although I am not able to test it there.

The PR also requires moving the main execution code under ``if __name__ == '__main__'`` to a separate function, which I called ``main()``, with a call from the former, so running the script directly using the Python interpreter will still work in the same way.